### PR TITLE
build(goreleaser): remove go mod tidy

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,4 @@
 project_name: falco-exporter
-before:
-  hooks:
-    - go mod tidy
 builds:
   - id: "falco-exporter"
     goos:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

This PR removes the `go mod tidy` step from the goreleaser's config, that prevents `go.mod` from being modified during the releasing process.
Thus, it ensures that the published artifact is built with the exact dependencies listed by the `go.mod` within the source.

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

Indirectly, this also fixes the [issue we had when we tried to release the v0.2.0](https://app.circleci.com/pipelines/github/falcosecurity/falco-exporter/23/workflows/37dea122-0b4b-4714-bad1-064b668d3a5e/jobs/25/steps) even though it was originally caused by https://github.com/falcosecurity/client-go/issues/46


/cc @fntlnz 
/cc @leodido 

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```