### PR TITLE
update(.github): remove release-note block from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--  Thanks for sending a pull request!  Here are some tips for you:
 
-1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
 2. Please label this pull request according to what type of issue you are addressing.
 3. Please add a release note: it's really useful for the changelog!
 4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
@@ -53,4 +53,3 @@ Fixes #
 **Special notes for your reviewer**:
 
 
-```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -52,16 +52,5 @@ Fixes #
 
 **Special notes for your reviewer**:
 
-**Does this PR introduce a user-facing change?**:
-
-<!--
-If no, just write "NONE" in the release-note block below.
-If yes, a release note is required:
-Enter your extended release note in the block below.
-If the PR requires additional action from users switching to the new release, prepend the string "action required:".
-For example, `action required: change the API interface of the rule engine`.
--->
-
-```release-note
 
 ```


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>



**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

NONE

**What this PR does / why we need it**:

Follow-up from https://github.com/falcosecurity/test-infra/pull/154

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



```release-note
NONE
```