### PR TITLE
fix: Separate probes from main server to avoid mTLS conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,18 @@ Command line usage:
 ```
 $ ./falco-exporter --help
 Usage of ./falco-exporter:
-      --client-ca string         CA root file path for connecting to a Falco gRPC server (default "/etc/falco/certs/ca.crt")
-      --client-cert string       cert file path for connecting to a Falco gRPC server (default "/etc/falco/certs/client.crt")
-      --client-hostname string   hostname for connecting to a Falco gRPC server, if set, takes precedence over --client-socket
-      --client-key string        key file path for connecting to a Falco gRPC server (default "/etc/falco/certs/client.key")
-      --client-port uint16       port for connecting to a Falco gRPC server (default 5060)
-      --client-socket string     unix socket path for connecting to a Falco gRPC server (default "unix:///var/run/falco.sock")
-      --listen-address string    address on which to expose the Prometheus metrics (default ":9376")
-      --server-ca string         CA root file path for metrics https server
-      --server-cert string       cert file path for metrics https server
-      --server-key string        key file path for metrics https server
-      --timeout duration         timeout for initial gRPC connection (default 2m0s)
+      --client-ca string                CA root file path for connecting to a Falco gRPC server (default "/etc/falco/certs/ca.crt")
+      --client-cert string              cert file path for connecting to a Falco gRPC server (default "/etc/falco/certs/client.crt")
+      --client-hostname string          hostname for connecting to a Falco gRPC server, if set, takes precedence over --client-socket
+      --client-key string               key file path for connecting to a Falco gRPC server (default "/etc/falco/certs/client.key")
+      --client-port uint16              port for connecting to a Falco gRPC server (default 5060)
+      --client-socket string            unix socket path for connecting to a Falco gRPC server (default "unix:///var/run/falco.sock")
+      --listen-address string           address on which to expose the Prometheus metrics (default ":9376")
+      --probes-listen-address string    address on which to expose readiness/liveness probes endpoints (default ":19376")
+      --server-ca string                CA root file path for metrics https server
+      --server-cert string              cert file path for metrics https server
+      --server-key string               key file path for metrics https server
+      --timeout duration                timeout for initial gRPC connection (default 2m0s)
 ```
 
 ### Run with Docker

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,5 +17,6 @@ WORKDIR /opt/falco-exporter
 COPY --from=builder /opt/falco-exporter/falco-exporter /usr/bin/falco-exporter
 
 EXPOSE 9376/tcp
+EXPOSE 19376/tcp
 
 ENTRYPOINT ["/usr/bin/falco-exporter"]


### PR DESCRIPTION
Signed-off-by: Jose Angel Santiago <>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area commands

**What this PR does / why we need it**:

It makes falco-exporter probes run on a different server/port from main server (metrics). It's necessary becasue when falco-exporter is deployed with mTLS configuration, liveness and readiness probes are unreachable from the Kubelet when deployed as part of a Deployment in K8s.

**Which issue(s) this PR fixes**:

Fixes #50 

**Special notes for your reviewer**:

Most of the credit for this code goes for @leogr 
