### PR TITLE
update(cmd): make `unix://` prefix optional for `--client-socket`

### DIFF
--- a/cmd/falco-exporter/root.go
+++ b/cmd/falco-exporter/root.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/falcosecurity/client-go/pkg/client"
@@ -61,6 +62,9 @@ func main() {
 		config.UnixSocketPath = ""
 		log.Printf("connecting to gRPC server at %s:%d (timeout %s)", config.Hostname, config.Port, timeout)
 	} else {
+		if !strings.HasPrefix("unix://", config.UnixSocketPath) {
+			config.UnixSocketPath = "unix://" + config.UnixSocketPath
+		}
 		log.Printf("connecting to gRPC server at %s (timeout %s)", config.UnixSocketPath, timeout)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area commands


**What this PR does / why we need it**:

It makes flag usage less error-prone.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


