### PR TITLE
fix(falco): Only show non-zero rates in Grafana

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -84,7 +84,7 @@
       },
       "lines": true,
       "linewidth": 1,
-      "nullPointMode": "null",
+      "nullPointMode": "null as zero",
       "options": {
         "dataLinks": []
       },
@@ -98,7 +98,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(falco_events[5m])",
+          "expr": "rate(falco_events[5m]) > 0",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{rule}} (node=\"{{kubernetes_node}}\",ns=\"{{k8s_ns_name}}\",pod=\"{{k8s_pod_name}}\")",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area examples

**What this PR does / why we need it**:

Port of https://github.com/falcosecurity/charts/pull/185

> Adjust Grafana dashboard to only show events with non-zero rate.
>
> Currently where there are large numbers of alerts that have previously fired, these are exported to Prometheus and therefore show in the graph legend making it difficult to read.
>
> With this change, alerts now only shows in the legend if they have occurred within the time range for the dashboard.

**Special notes for your reviewer**:


