### PR TITLE
added health port to the k8s daemonset template

### DIFF
--- a/deploy/k8s/falco-exporter/templates/daemonset.yaml
+++ b/deploy/k8s/falco-exporter/templates/daemonset.yaml
@@ -36,6 +36,9 @@ spec:
             - name: metrics
               containerPort: 9376
               protocol: TCP
+            - name: health
+              containerPort: 19376
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /liveness


### PR DESCRIPTION
Signed-off-by: Wulf Thimm <thimm.wulf@gmail.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

> /area pkg

> /area examples

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
The falco-exporter did not get ready because the port 19376 was not accessable.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


