### PR TITLE
cleanup(OWNERS): remove inactive approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,9 @@
 approvers:
-  - leodido
   - leogr
   - jasondellaluce
 reviewers:
   - leodido
   - leogr
   - jasondellaluce
+emeritus_approvers:
+  - leodido


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:

For https://github.com/falcosecurity/falco/issues/2115, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

Considering the low activity of this repository, devstats have also been consulted for the past year: https://falco.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=falcosecurity%2Ffalco-exporter&var-country_name=All

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
