### PR TITLE
make gRPC authentication an option!

### DIFF
--- a/cmd/falco-exporter/root.go
+++ b/cmd/falco-exporter/root.go
@@ -51,6 +51,8 @@ func main() {
 	pflag.StringVar(&config.CertFile, "client-cert", "/etc/falco/certs/client.crt", "cert file path for connecting to a Falco gRPC server")
 	pflag.StringVar(&config.KeyFile, "client-key", "/etc/falco/certs/client.key", "key file path for connecting to a Falco gRPC server")
 	pflag.StringVar(&config.CARootFile, "client-ca", "/etc/falco/certs/ca.crt", "CA root file path for connecting to a Falco gRPC server")
+	pflag.BoolVar(&config.GRPCAuth, "grpc-auth", true, "Whether or not falco-exporter authenticates itself to the gRPC server")
+
 
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	pflag.Parse()


### PR DESCRIPTION
<!-- This is related to a PR I created for falco's go client, it only makes sense if that one is also approved
-->

This PR is the continuation of [this PR](https://github.com/falcosecurity/client-go/pull/65), which lays the groundwork required on the client package to allow for gRPC authentication to be an option.

This is a fix I made for myself, why not share it with the community?

/kind feature

/area pkg

Note: for this feature to be fully 'usable', adjustments would also have to be made to the helm chart, I will create PRs once and if both of these are approved


