### PR TITLE
Update base image from alpine:3.16 to alpine:3.18

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 RUN make
 
-FROM alpine:3.16
+FROM alpine:3.18
 WORKDIR /opt/falco-exporter
 
 COPY --from=builder /opt/falco-exporter/falco-exporter /usr/bin/falco-exporter


### PR DESCRIPTION

/kind cleanup

/area pkg


**What this PR does / why we need it**: Alpine 3.16 is End of support since 2024-05-23.

**Which issue(s) this PR fixes**:  N/a


